### PR TITLE
TOML: include poetry.lock files

### DIFF
--- a/TOML/TOML.sublime-syntax
+++ b/TOML/TOML.sublime-syntax
@@ -3,6 +3,7 @@
 name: TOML
 file_extensions:
   - toml
+  - poetry.lock
 scope: source.toml
 
 variables:


### PR DESCRIPTION
poetry [1] lock files are just toml files. I looked for other examples of exact filenames in the matchers and for example makefile.in files are just listed under file_extensions.

[1]: https://python-poetry.org/
